### PR TITLE
Increase default AMSDU buffer size iwlwifi

### DIFF
--- a/debians/wlanpi-linux-firmware/iwlwifi.conf
+++ b/debians/wlanpi-linux-firmware/iwlwifi.conf
@@ -1,0 +1,1 @@
+options iwlwifi amsdu_size=3

--- a/debians/wlanpi-linux-firmware/rules
+++ b/debians/wlanpi-linux-firmware/rules
@@ -15,4 +15,5 @@ override_dh_auto_install:
 	mkdir -p $(DEB_PATH)/lib/firmware/intel
 	cp iwlwifi* $(DEB_PATH)/lib/firmware/
 	cp intel/ibt* $(DEB_PATH)/lib/firmware/intel/
+	install -o root -g root -m 644 $(DEB_PATH)/iwlwifi.conf $(DEB_PATH)/etc/modprobe.d/
 	dh_auto_install


### PR DESCRIPTION
From Josh Schmelzle:
default buffer for ax210 on ucode 66/67 is amsdu_size:amsdu size 0: 12K
for multi Rx queue devices, 2K for AX210 devices, 4K for other devices
1:4K 2:8K 3:12K (16K buffers) 4: 2K (default 0) (int).

so, let's set it to 3 for a 12K buffer. based on my testing, this is a
huge improvement when capturing 802.11 data frames. the thought here is
the wrong default buffer size was chosen for the ax210.

Signed-off-by: Daniel Finimundi <daniel@finimundi.com>