### PR TITLE
Target trixie only and bump iperf 2.2.2, iperf3 3.21, wavemon v0.9.7, iwlwifi firmware 2026-07-02

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -28,9 +28,9 @@ jobs:
       - id: set-matrix
         run: |
           if [ "${{ github.event.inputs.packages }}" = "all" ]; then
-            echo 'matrix={"package": ["iw", "wlanpi-linux-firmware", "iperf", "iperf3", "wavemon", "wpasupplicant", "hostapd"], "distro": ["bookworm", "trixie"], "arch": ["arm64"]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"package": ["iw", "wlanpi-linux-firmware", "iperf", "iperf3", "wavemon", "wpasupplicant", "hostapd"], "distro": ["trixie"], "arch": ["arm64"]}' >> $GITHUB_OUTPUT
           else
-            echo 'matrix={"package": ["${{ github.event.inputs.packages }}"], "distro": ["bookworm", "trixie"], "arch": ["arm64"]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"package": ["${{ github.event.inputs.packages }}"], "distro": ["trixie"], "arch": ["arm64"]}' >> $GITHUB_OUTPUT
           fi
 
   build:
@@ -64,7 +64,7 @@ jobs:
       - name: Check debootstrap logs
         if: failure()
         run: |
-          for distro in bookworm trixie; do
+          for distro in trixie; do
             logfile="/srv/chroot/${distro}-${{ matrix.arch }}-sbuild/debootstrap/debootstrap.log"
             if [ -f "$logfile" ]; then
               echo "=== $distro logs ==="

--- a/debians/iperf/changelog
+++ b/debians/iperf/changelog
@@ -1,4 +1,4 @@
-iperf (2.2.0-0wlanpi0) unstable; urgency=medium
+iperf (2.2.2-0wlanpi0) unstable; urgency=medium
 
   * Initial WLAN Pi package for iperf
 

--- a/iperf.conf
+++ b/iperf.conf
@@ -1,6 +1,6 @@
 # iperf
 local package_name="iperf"
 local package_url="https://git.code.sf.net/p/iperf2/code"
-local package_ref="2-2-0"
+local package_ref="2-2-2"
 local package_version=""
 local package_version_type="describe"

--- a/iperf3.conf
+++ b/iperf3.conf
@@ -1,6 +1,6 @@
 # iperf 3
 local package_name="iperf3"
 local package_url="https://github.com/esnet/iperf.git"
-local package_ref="3.18"
+local package_ref="3.21"
 local package_version=""
 local package_version_type="describe"

--- a/package.sh
+++ b/package.sh
@@ -15,8 +15,8 @@ NUM_CORES=$(($(nproc)/2))
 EXEC_FUNC=""
 BUILD_ALL="0"
 BUILD_PACKAGE=""
-BUILD_DISTRO="bookworm"
-DISTRO="bookworm"
+BUILD_DISTRO="trixie"
+DISTRO="trixie"
 export DEBFULLNAME="Josh Schmelzle"
 export DEBEMAIL="josh@joshschmelzle.com"
 

--- a/wavemon.conf
+++ b/wavemon.conf
@@ -1,6 +1,6 @@
 # wavemon
 local package_name="wavemon"
 local package_url="https://github.com/uoaerg/wavemon.git"
-local package_ref="v0.9.6"
+local package_ref="v0.9.7"
 local package_version=""
 local package_version_type="describe"

--- a/wlanpi-linux-firmware.conf
+++ b/wlanpi-linux-firmware.conf
@@ -1,6 +1,6 @@
 # wlanpi-linux-firmware
 local package_name="wlanpi-linux-firmware"
 local package_url="https://git.kernel.org/pub/scm/linux/kernel/git/iwlwifi/linux-firmware.git"
-local package_ref="iwlwifi-fw-2026-01-15"
+local package_ref="iwlwifi-fw-2026-07-02"
 local package_version=""
 local package_version_type="date"


### PR DESCRIPTION
## Summary

Moves all package builds to Debian trixie only and bumps upstream versions:

| Package | Before | After |
|---|---|---|
| iperf | 2-2-0 | 2-2-2 (branch; upstream has no tags) |
| iperf3 | 3.18 | 3.21 |
| wavemon | v0.9.6 | v0.9.7 |
| wlanpi-linux-firmware | iwlwifi-fw-2026-01-15 | iwlwifi-fw-2026-07-02 |
| hostapd / wpasupplicant | 2.11 | unchanged |
| iw | v6.17 | unchanged |

## Details

- CI matrix now builds `trixie` only (bookworm removed); `package.sh` default `--distro` updated to match.
- iperf2 upstream (SourceForge) has no version tags, so `package.sh` derives the version from `debians/iperf/changelog` — bumped that entry to `2.2.2-0wlanpi0` alongside the ref change (same approach as the 2.2.0 bump).
- Verified `iwlwifi-fw-2026-07-02` still ships the `intel/iwlwifi/` and `intel/ibt*` layout that `debians/wlanpi-linux-firmware/rules` copies from.
- hostapd/wpasupplicant/iw need no file changes: `dch -D` stamps the distro at build time.

## Test plan

- [x] `bash -n package.sh` and workflow YAML parse clean
- [x] All upstream refs verified to exist (`git ls-remote`)
- [ ] After merge: dispatch **Build misc packages** with `packages=all` and confirm 7 trixie/arm64 jobs upload `.deb`s to packagecloud `debian/trixie` (expect iperf `2.2.2-1wlanpi1`, iperf3 `3.21-1wlanpi1`, wavemon `0.9.7-1wlanpi1`, firmware `1.20260xxx-1wlanpi1`)

Note: `package.sh` passes `libncurses5-dev` as an extra sbuild dep for wavemon; on trixie it's only a transitional name for `libncurses-dev`. If the wavemon job fails on dependency resolution, that's the first thing to swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)