### PR TITLE
Fix trixie CI failures from run 29063363107

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ steps.build-package.outputs.deb-package != '' }}
         with:
-          name: ${{ matrix.package }}-${{ matrix.arch }}-${{ matrix.distro }}-${{ steps.build-package.outputs.package-version }}
+          name: ${{ matrix.package }}-${{ matrix.arch }}-${{ matrix.distro }}-${{ steps.build-package.outputs.artifact-version }}
           path: ${{ steps.build-package.outputs.deb-package }}
 
       - name: Upload arm64 package to packagecloud debian/${{ matrix.distro }} 

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.tar.xz
 /iw
 /wavemon
-/iperf2
+/iperf
 /iperf3
 /hostapd
 /wpasupplicant

--- a/debians/iperf/changelog
+++ b/debians/iperf/changelog
@@ -1,3 +1,9 @@
+iperf (2.2.2-1wlanpi1) trixie; urgency=medium
+
+  * iperf version 2.2.2-1wlanpi1
+
+ -- Josh Schmelzle <josh@joshschmelzle.com>  Fri, 10 Jul 2026 01:53:00 +0000
+
 iperf (2.2.2-0wlanpi0) unstable; urgency=medium
 
   * Initial WLAN Pi package for iperf

--- a/debians/iperf3/control
+++ b/debians/iperf3/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Josh Schmelzle <josh@joshschmelzle.com>
 Build-Depends: debhelper-compat (= 12), 
                autotools-dev,
-               autoconf-2.71 | autoconf (>= 2.71~)
+               autoconf (>= 2.71~)
 Standards-Version: 4.5.0
 Homepage: https://github.com/esnet/iperf
 

--- a/package.sh
+++ b/package.sh
@@ -225,6 +225,8 @@ build_packages()
 
         if [[ -n "${GITHUB_OUTPUT}" ]] && [[ -w "${GITHUB_OUTPUT}" ]]; then
             echo "package-version=${full_package_version}" >> $GITHUB_OUTPUT
+            # Epoch-less version for GitHub artifact names, which reject ':'
+            echo "artifact-version=${full_package_version#*:}" >> $GITHUB_OUTPUT
             echo "deb-package=${package_name}_${full_package_version}_${BUILD_ARCH}.deb" >> $GITHUB_OUTPUT
         else
             echo "GITHUB_OUTPUT is not set or not writable"
@@ -253,6 +255,12 @@ build_packages()
             # git archive --format=tar --prefix="${package_name}-${upstream_version}/" HEAD | xz > "../${package_name}_${upstream_version}.orig.tar.xz"
             git archive --format=tar HEAD | xz -T0 > "../${package_name}_${package_version%-*}.orig.tar.xz"
             INPUTS_ARCH=${BUILD_ARCH} INPUTS_DISTRO="${BUILD_DISTRO}" INPUTS_RUN_LINTIAN="false" INPUTS_EXTRA_DEPENDS="${EXTRA_DEPENDS}" "${SCRIPT_PATH}"/sbuild-debian-package/build.sh
+            # sbuild failures (e.g. unsatisfiable build deps) don't propagate out
+            # of build.sh, so verify a .deb was actually produced
+            if [ -z "$(find . -maxdepth 1 -name '*.deb' -print -quit)" ]; then
+                log "error" "No .deb produced for ${package_name}; sbuild failed"
+                exit 1
+            fi
             find . -name "*.deb" -exec cp {} "${SCRIPT_PATH}" \;
         )
         package_built="1"


### PR DESCRIPTION
## Summary

Fixes all four failure modes from the first trixie-only run of **Build misc packages** — including one that reported green while building nothing.

| Package | What happened | Fix |
|---|---|---|
| hostapd, wpasupplicant | Built fine, but artifact name `hostapd-arm64-trixie-2:2.11-2wlanpi1` rejected (GitHub forbids `:`); job died before packagecloud upload | New epoch-less `artifact-version` output from `package.sh`, used for the artifact name |
| iperf | Built + pushed `2.2.2-1wlanpi1` to packagecloud, then create-pull-request failed: `.gitignore` still had `/iperf2` (pre-rename), so the untracked `iperf/` clone tricked the action into an empty commit | `.gitignore`: `/iperf2` → `/iperf`; changelog entry for `2.2.2-1wlanpi1` added here since the CI changelog PR was lost |
| iperf3 | **Silent failure** — job green, nothing built. sbuild only tries the first build-dep alternative, and `autoconf-2.71` (our bookworm backport) doesn't exist on trixie → `given-back`. build.sh doesn't propagate the error and the packagecloud action exits 0 on errors (`PACKAGE_NAME=` was empty) | Build-Depends → `autoconf (>= 2.71~)` (trixie ships 2.72); `package.sh` now fails hard when no `.deb` is produced |

## After merging

Re-run only what's missing from packagecloud debian/trixie:
```
gh workflow run build-packages.yml -f packages=iperf3
gh workflow run build-packages.yml -f packages=hostapd
gh workflow run build-packages.yml -f packages=wpasupplicant
```
iw, wlanpi-linux-firmware, wavemon, and iperf are already uploaded — merge changelog PRs #97, #98, #99 (iperf's equivalent is included here) so future runs increment versions correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)