### PR TITLE
hostapd: fix trixie unpack failure (units shipped through /lib alias)

### DIFF
--- a/debians/hostapd/rules
+++ b/debians/hostapd/rules
@@ -40,10 +40,10 @@ execute_after_dh_install:
 
 	install --mode=755 -D debian/hostapd.init debian/hostapd/etc/init.d/hostapd
 
-	install --mode=644 -D debian/hostapd.service \
-		debian/hostapd/lib/systemd/system/hostapd.service
-	install --mode=644 -D debian/hostapd@.service \
-		debian/hostapd/lib/systemd/system/hostapd@.service
+	# systemd units are installed by dh_installsystemd to the canonical
+	# /usr/lib/systemd/system. Installing them to /lib/systemd/system as
+	# well shipped the same files through the merged-/usr alias, which
+	# trixie's dpkg rejects at unpack.
 
 	install --mode=644 -D README debian/hostapd/usr/share/doc/hostapd/README.gz
 	install --mode=644 -D debian/hostapd.README.Debian debian/hostapd/usr/share/doc/hostapd/README.Debian


### PR DESCRIPTION
Fixes the trixie image build failure:

```
Unpacking hostapd (2:2.11-2wlanpi1) ...
dpkg: error processing archive .../hostapd_2%3a2.11-2wlanpi1_arm64.deb (--unpack):
 unable to open '/usr/lib/systemd/system/hostapd.service.dpkg-new': No such file or directory
```

Inspected the published deb: it ships `hostapd.service` and `hostapd@.service` under **both** `/lib/systemd/system` and `/usr/lib/systemd/system`. The rules file installs them manually to `/lib/systemd/system`, while dh_installsystemd (compat 12, trixie debhelper) auto-installs the same units to the canonical `/usr/lib/systemd/system`. On bookworm both paths coincided; on trixie the duplicate through the merged-/usr alias makes dpkg fail at unpack (DEP17).

Fix: drop the manual installs and let dh_installsystemd own the units. One copy, canonical path.

After merge: dispatch **Build misc packages** with `packages=hostapd`. package.sh auto-increments to `2:2.11-3wlanpi1`. Then verify the new version appears in the [trixie index](https://packagecloud.io/wlanpi/dev/debian/dists/trixie/main/binary-arm64/Packages) and, ideally, that `apt install hostapd` unpacks clean in a trixie container.

Checked wpasupplicant for the same disease: clean, it ships no systemd units (only the D-Bus activation file under /usr/share). Note for later: wlanpi-linux-firmware ships to `/lib/firmware`, which works today but the canonical path on trixie is `/usr/lib/firmware`; worth migrating when convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)